### PR TITLE
Implement `confgen set path key` functionality

### DIFF
--- a/confgen/cli.py
+++ b/confgen/cli.py
@@ -1,3 +1,4 @@
+import errno
 import click
 import yaml
 from jinja2 import Environment, FileSystemLoader
@@ -23,8 +24,18 @@ def flatten_dict(d, parent_key='', sep='/'):
             items.append((new_key, v))
     return dict(items)
 
+def mkdir_p(path):
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
+
 class Inventory(object):
     inventory_delimiter = '/'
+    config_filename = 'config.yaml'
 
     def __init__(self, home=None):
         self.home = home
@@ -37,9 +48,22 @@ class Inventory(object):
         inventory = {}
         for path, dirs, files in os.walk(self.inventory_dir):
             if files:
-                configyml = yaml.load(open(join(path, 'config.yaml')))
+                configyml = yaml.load(open(join(path, self.config_filename)))
                 inventory['/' + path[len(self.inventory_dir) + 1:]] = configyml
         return inventory
+
+    def set(self, path, key, value):
+        collected = self.collect()
+        if path not in collected:
+            collected[path] = {}
+        collected[path][key] = value
+        self.flush(collected)
+
+    def flush(self, inventory):
+        for path, contents in inventory.items():
+            dst_dir = join(self.inventory_dir, path.strip('/'))
+            mkdir_p(dst_dir)
+            yaml.dump(contents, open(join(dst_dir, self.config_filename), 'w+'))
 
     def build(self):
         '''
@@ -137,6 +161,9 @@ class ConfGen(object):
     def build(self):
         self.flush(self.collect())
 
+    def set(self, path, key, value):
+        self.inventory.set(path, key, value)
+
 @click.group()
 @click.option('--ct-home', envvar='CG_HOME', default='.',
               type=click.Path(exists=True, file_okay=False, resolve_path=True),
@@ -172,8 +199,10 @@ def build(ctx):
 @click.argument('path')
 @click.argument('key')
 @click.argument('value')
-def set(path, key, value):
-    click.echo("will set the value: {}, at key: {} and path:{}".format(value, key, path))
+@click.pass_obj
+def set(ctx, path, key, value):
+    ctx.set(path, key, value)
+
 
 @cli.command()
 @click.argument('path')

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ read_file = lambda x: [l.strip() for l in open(x).readlines()]
 
 setup(
     name='confgen',
-    version='0.1.0',
+    version='0.2.0',
     packages=find_packages(),
     scripts=["bin/confgen"],
     install_requires=read_file("requirements.txt"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import shutil
+import tempfile
 import yaml
 import os
 from click.testing import CliRunner
@@ -6,12 +8,16 @@ from confgen.cli import Inventory, Renderer, ConfGen
 
 pwd = os.path.dirname(os.path.abspath(__file__))
 
-simplerepo = lambda x: os.path.join(os.path.join(pwd, 'simplerepo'), x)
-
+@pytest.fixture
+def simplerepo(request):
+    rootdir = tempfile.mkdtemp()
+    simplerepo_dst = os.path.join(rootdir, 'simplerepo')
+    shutil.copytree(os.path.join(pwd, 'simplerepo'), simplerepo_dst)
+    return simplerepo_dst
 
 @pytest.fixture
-def confgenyaml(request):
-    return yaml.load(open(simplerepo('confgen.yaml')))
+def confgenyaml(simplerepo, request):
+    return yaml.load(open(os.path.join(simplerepo, 'confgen.yaml')))
 
 @pytest.fixture
 def runner(confgenyaml):
@@ -19,13 +25,13 @@ def runner(confgenyaml):
     return runner
 
 @pytest.fixture
-def inventory():
-    return Inventory(home=simplerepo('.'))
+def inventory(simplerepo):
+    return Inventory(home=simplerepo)
 
 @pytest.fixture
-def renderer(confgenyaml, inventory):
-    return Renderer(confgenyaml['service'], home=simplerepo('.'))
+def renderer(confgenyaml, inventory, simplerepo):
+    return Renderer(confgenyaml['service'], home=simplerepo)
 
 @pytest.fixture
-def confgen(request):
-    return ConfGen(home=simplerepo('.'), config=open(simplerepo('confgen.yaml')))
+def confgen(request, simplerepo):
+    return ConfGen(home=simplerepo, config=open(os.path.join(simplerepo, 'confgen.yaml')))

--- a/tests/test_confg_builder.py
+++ b/tests/test_confg_builder.py
@@ -20,3 +20,28 @@ def test_build_inventory(inventory):
         '/prod/main': {'mysql': 3.0, 'secret': 'password'},
         '/test': {'mysql': 1.0, 'secret': 'plaintext'}
     }
+
+def test_set_new_value_existing_path(inventory):
+    inventory.set('/', 'foo', 'bar')
+    loaded = inventory.collect()
+    assert loaded == {
+        '/': {'mysql': 1.0, 'secret': 'password', 'foo': 'bar'},
+        '/dev/qa1': {'mysql': 4.0},
+        '/dev/qa2': {'mysql': 9.0},
+        '/prod': {'mysql': 2.0},
+        '/prod/main': {'mysql': 3.0},
+        '/test': {'secret': 'plaintext'},
+    }
+
+def test_set_set_value_new_path(inventory):
+    inventory.set('/staging/demo1', 'foo', 'bar')
+    loaded = inventory.collect()
+    assert loaded == {
+        '/': {'mysql': 1.0, 'secret': 'password'},
+        '/dev/qa1': {'mysql': 4.0},
+        '/dev/qa2': {'mysql': 9.0},
+        '/prod': {'mysql': 2.0},
+        '/prod/main': {'mysql': 3.0},
+        '/test': {'secret': 'plaintext'},
+        '/staging/demo1': {'foo': 'bar'},
+    }


### PR DESCRIPTION
Updating inventory with this command will add necessary keys to existing
config.yaml files or it will create new ones.
The way of dumping structs to yaml files is transparent to the library,
but the representation changes. Because while setting single key, the
entire inventory is rebuilt (simpler) first build might seem weird.

Notation <key>: <value> will be changed to {<key>: <value>}
-mysql: 2.0
+{mysql: 2.0}

Also strings are represented differently:

!!python/unicode 'secret': !!python/unicode 'sUpEr'}

I am not sure if this is a implementation bug or if it's a valid yaml
representation of python structures.

- [ ] @io41 