### PR TITLE
Dont ignore missing undefined keys in jinja2 templates

### DIFF
--- a/confgen/cli.py
+++ b/confgen/cli.py
@@ -4,7 +4,7 @@ import logging
 from logic import ConfGen
 from . import __version__
 
-logging.getLogger('confgen').addHandler(logging.StreamHandler())
+logging.basicConfig(format='[%(levelname)s] %(message)s')
 log = logging.getLogger('confgen')
 
 @click.group()

--- a/tests/test_rendenring.py
+++ b/tests/test_rendenring.py
@@ -1,3 +1,5 @@
+import pytest
+
 def test_collect_templates(renderer):
     assert renderer.collect_templates(renderer.services) == {
         'api': ['api/my.cnf'],
@@ -40,3 +42,11 @@ def test_render_templates_for_multiple_service_and_inventory(renderer, inventory
         'webapp/my.cnf': u'# mysql:/ override:/prod,/prod/main\n# secret:/\nconnurl = 3.0:password',
         'webapp/production.ini': u'# mysql:/ override:/prod,/prod/main\nmysql = 3.0\n\n# secret:/\npassword = password',
     }
+
+def test_render_template_with_undefined_key(renderer, inventory):
+    built_inventory = inventory.build()
+
+    built_inventory['/prod/main'].pop('secret') # remove required key to render
+
+    with pytest.raises(SystemExit):
+        renderer.render_templates('webapp', built_inventory['/prod/main'])


### PR DESCRIPTION
To keep templates clean, make sure that all none of the keys are
undentified. Log a helpful message upon the error and exit with 1 code.
while rendering: webapp/my.cnf ('secret' is undefined)